### PR TITLE
New mapping response

### DIFF
--- a/src/constants/CommonTypes.ts
+++ b/src/constants/CommonTypes.ts
@@ -1,3 +1,3 @@
 export type StringVoidFun = (id: string) => void
-export enum Assembly { GRCh38="GRCh38", GRCh37="GRCh37"}
+export enum Assembly { GRCh38="GRCh38", GRCh37="GRCh37", AUTO="AUTO"}
 export const DEFAULT_ASSEMBLY = Assembly.GRCh38

--- a/src/constants/SearchResultTable.ts
+++ b/src/constants/SearchResultTable.ts
@@ -1,6 +1,5 @@
 export const TOTAL_COLS = 15;
-export const INPUT_COLS = 5;
-export const GENOMIC_COLS = 3;
+export const GENOMIC_COLS = 8;
 export const PROTEIN_COLS = 6;
 export const ANNOTATION_COLS = 1;
 export const ALLELE: Map<string, string> = new Map(Object.entries({

--- a/src/styles/search/_ImpactSearchResults.scss
+++ b/src/styles/search/_ImpactSearchResults.scss
@@ -280,9 +280,7 @@
 			border-top: 1px dotted #ccc;
 			border-bottom: 1px dotted #ccc;
 		}
-		tr:nth-child(even) {
-			background-color: $search-results-table-zebra-background-colour;
-		}
+
 
 		th {
 			background-color: $search-results-table-header-background-colour;
@@ -302,7 +300,7 @@
 		}
 
 		td {
-			border-bottom: 1px solid $search-results-divider-border-colour;
+			//border-bottom: 1px solid $search-results-divider-border-colour;
 			font-size: 0.9rem;
 			padding: 0;
 			/* width: fit-content; */
@@ -310,8 +308,8 @@
 			width: 0.1%;
 			white-space: nowrap;
 			padding: 0.3rem 0.5rem;
-			border-right: 1px dotted #ccc;
-			border-left: 1px dotted #ccc;
+			//border-right: 1px dotted #ccc;
+			//border-left: 1px dotted #ccc;
 			word-wrap: break-word;
 		}
 

--- a/src/types/MappingResponse.ts
+++ b/src/types/MappingResponse.ts
@@ -1,16 +1,65 @@
-interface MappingResponse {
-  mappings: Array<GenomeProteinMapping>;
-  invalidInputs: Array<ParsedInput>;
+export interface MappingResponse {
+  inputs: Array<GenomicInput|ProteinInput|RSInput>
+  messages: Array<Message>
 }
+
+export interface Message {
+  type: string
+  text: string
+}
+
+export const INPUT_GEN = 'GEN'
+export const INPUT_PRO = 'PRO'
+export const INPUT_RS = 'RS'
+
+export const INFO = 'INFO'
+export const WARN = 'WARN'
+export const ERROR = 'ERROR'
+
+export interface UserInput {
+  inputStr: string
+  messages: Array<Message>
+  type: string
+  valid: boolean
+}
+
+export interface Message {
+  type: string
+  text: string
+}
+
+export interface GenomicInput extends UserInput {
+  chr:string
+  pos:number
+  ref:string
+  alt:string
+  id:string
+  converted:boolean
+  mappings:Array<GenomeProteinMapping>
+}
+
+export interface ProteinInput extends UserInput {
+  acc:string
+  pos:number
+  ref:string
+  alt:string
+  derivedGenomicInputs:Array<GenomicInput>
+}
+
+export interface RSInput extends UserInput {
+  id:string
+  derivedGenomicInputs:Array<GenomicInput>
+}
+
 export interface GenomeProteinMapping {
-  chromosome: string;
-  geneCoordinateStart: number;
-  geneCoordinateEnd: number;
-  id: string;
-  userAllele: string;
-  variantAllele: string;
+  //chromosome: string;
+  //geneCoordinateStart: number;
+  //geneCoordinateEnd: number;
+  //id: string;
+  //userAllele: string;
+  //variantAllele: string;
   genes: Array<Gene>;
-  input: string;
+  //input: string;
 }
 interface Gene {
   ensg: string;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3,7 +3,7 @@ import {Route, RouteComponentProps, withRouter} from "react-router-dom";
 import HomePage from "./pages/home/HomePage";
 import SearchResultsPage from "./pages/search/SearchResultPage";
 import APIErrorPage from "./pages/APIErrorPage";
-import {ERROR, INFO, ParsedInput, WARN} from "../types/MappingResponse";
+import {ERROR, INFO, WARN} from "../types/MappingResponse";
 import {convertApiMappingToTableRecords, MappingRecord,} from "../utills/Convertor";
 import {firstPage, Page} from "../utills/AppHelper";
 import AboutPage from "./pages/AboutPage";

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3,7 +3,7 @@ import {Route, RouteComponentProps, withRouter} from "react-router-dom";
 import HomePage from "./pages/home/HomePage";
 import SearchResultsPage from "./pages/search/SearchResultPage";
 import APIErrorPage from "./pages/APIErrorPage";
-import {ParsedInput} from "../types/MappingResponse";
+import {ERROR, INFO, ParsedInput, WARN} from "../types/MappingResponse";
 import {convertApiMappingToTableRecords, MappingRecord,} from "../utills/Convertor";
 import {firstPage, Page} from "../utills/AppHelper";
 import AboutPage from "./pages/AboutPage";
@@ -21,7 +21,29 @@ function App(props: AppProps) {
   const [userInputs, setUserInputs] = useState<string[]>([]);
   const [file, setFile] = useState<File | null>(null);
   const [searchResults, setSearchResults] = useState<MappingRecord[][][]>([]);
-  const [invalidInputs, setInvalidInputs] = useState<Array<ParsedInput>>([]);
+  // MappingRecord 3d array -> [][][] list of mappings/genes/isoforms
+    // mappings : [
+    //     ...
+    //     genes: [
+    //        ...
+    //        isoforms: [ -> for can, all fields; for non-can, no INPUT & GENOMIC fields, only PROTEIN fields
+    //           ...
+    //            ]
+    //     ]
+    // ]
+    // e.g.
+    // input 1   gene 1   isoform1 (can)
+    //                    isoform2 (non-can)
+    // input 2   gene 1   isoform 1 (can)
+    //                    isoform 2 (non-can)
+    //                    ...
+    //           gene 2  isoform 1 (can)
+    //                   isoform 2 (non-can)
+    //                   ...
+    //           ...
+    // ...
+
+
   const [page, setPage] = useState<Page>(firstPage(0));
   const [assembly, setAssembly] = useState(DEFAULT_ASSEMBLY)
 
@@ -105,15 +127,20 @@ function App(props: AppProps) {
   };
 
   function mappingApiCall(inputSubArray: string[]) {
+      console.log("in mappingApiCall " + assembly)
     mappings(inputSubArray, assembly.toString())
       .then((response) => {
-        const records = response.data.mappings.map(
-          convertApiMappingToTableRecords
-        );
+        const records = convertApiMappingToTableRecords(response.data.inputs);
         setSearchResults(records);
-        setInvalidInputs(response.data.invalidInputs);
-        if (response.data.invalidInputs.length > 0)
-          Notify.err("Some input rows are not valid");
+        response.data.messages.forEach(message => {
+            if (message.type === INFO) {
+                Notify.info(message.text)
+            } else if (message.type === WARN) {
+                Notify.warn(message.text)
+            } else if (message.type === ERROR) {
+                Notify.err(message.text)
+            }
+        });
         props.history.push(SEARCH);
       })
       .catch((err) => {
@@ -147,7 +174,6 @@ function App(props: AppProps) {
             page={page}
             pastedInputs={userInputs}
             fetchNextPage={fetchPage}
-            invalidInputs={invalidInputs}
             loading={loading}
           />
         )}

--- a/src/ui/components/function/ResidueRegionTable.tsx
+++ b/src/ui/components/function/ResidueRegionTable.tsx
@@ -81,6 +81,9 @@ function getRegions(regions: Array<ProteinFeature>, accession: string, pockets: 
       <label style={{ textAlign: 'center', fontWeight: 'bold' }}>
         No functional data for the region
       </label>
+      <br/><br/>
+      <b>Predictions</b>
+      <br/>(Source: PubMed ID <a href="https://pubmed.ncbi.nlm.nih.gov/36690744" target="_blank">15980494</a>)<br/>
       <Pockets pockets={pockets} expendedRowKey={expendedRowKey} toggleRow={toggleRow} />
       <Interfaces accession={accession} interactions={interactions} expendedRowKey={expendedRowKey} toggleRow={toggleRow} />
     </>);
@@ -92,7 +95,11 @@ function getRegions(regions: Array<ProteinFeature>, accession: string, pockets: 
     regionsList.push(list);
   });
   return <>
+    <b>Curated observations</b>
     {regionsList}
+    <br/><br/>
+    <b>Predictions</b>
+    <br/>(Source: PubMed ID <a href="https://pubmed.ncbi.nlm.nih.gov/36690744" target="_blank">15980494</a>)<br/>
     <Pockets pockets={pockets} expendedRowKey={expendedRowKey} toggleRow={toggleRow} />
     <Interfaces accession={accession} interactions={interactions} expendedRowKey={expendedRowKey} toggleRow={toggleRow} />
     </>
@@ -110,7 +117,7 @@ function getFeatureList(feature: ProteinFeature, key: string, expendedRowKey: st
 
   return <Fragment key={key}>
     <button type="button" className="collapsible" onClick={(e) => toggleRow(key)}>
-      {category}
+      {category ? category : 'Unnamed'}
       <ChevronDownIcon className="chevronicon" />
     </button>
     {getFeatureDetail(key, feature, expendedRowKey)}
@@ -167,6 +174,8 @@ function getFoldxDetail(foldxs: Array<Foldx>, rowKey: string, expendedRowKey: st
               <b title="Difference between the predicted ΔG before and after the variant. A value above 2 often indicates a destabilising variant.">ΔΔG<sub>pred</sub> :</b> {foldxs[0].foldxDdq}
               <br />
               <b title="AlphaFold per-residue confidence score (pLDDT).">pLDDT :</b> {foldxs[0].plddt}
+              <br />
+              (Source: PubMed ID <a href="http://www.ncbi.nlm.nih.gov/pubmed/15980494" target="_blank">15980494</a>)
             </li>
           </ul>
   }

--- a/src/ui/components/function/ResidueRegionTable.tsx
+++ b/src/ui/components/function/ResidueRegionTable.tsx
@@ -83,7 +83,7 @@ function getRegions(regions: Array<ProteinFeature>, accession: string, pockets: 
       </label>
       <br/><br/>
       <b>Predictions</b>
-      <br/>(Source: PubMed ID <a href="https://pubmed.ncbi.nlm.nih.gov/36690744" target="_blank">15980494</a>)<br/>
+      <br/>(Source: PubMed ID <a href="https://pubmed.ncbi.nlm.nih.gov/36690744" target="_blank" rel="noreferrer">15980494</a>)<br/>
       <Pockets pockets={pockets} expendedRowKey={expendedRowKey} toggleRow={toggleRow} />
       <Interfaces accession={accession} interactions={interactions} expendedRowKey={expendedRowKey} toggleRow={toggleRow} />
     </>);
@@ -99,7 +99,7 @@ function getRegions(regions: Array<ProteinFeature>, accession: string, pockets: 
     {regionsList}
     <br/><br/>
     <b>Predictions</b>
-    <br/>(Source: PubMed ID <a href="https://pubmed.ncbi.nlm.nih.gov/36690744" target="_blank">15980494</a>)<br/>
+    <br/>(Source: PubMed ID <a href="https://pubmed.ncbi.nlm.nih.gov/36690744" target="_blank" rel="noreferrer">15980494</a>)<br/>
     <Pockets pockets={pockets} expendedRowKey={expendedRowKey} toggleRow={toggleRow} />
     <Interfaces accession={accession} interactions={interactions} expendedRowKey={expendedRowKey} toggleRow={toggleRow} />
     </>
@@ -175,7 +175,7 @@ function getFoldxDetail(foldxs: Array<Foldx>, rowKey: string, expendedRowKey: st
               <br />
               <b title="AlphaFold per-residue confidence score (pLDDT).">pLDDT :</b> {foldxs[0].plddt}
               <br />
-              (Source: PubMed ID <a href="http://www.ncbi.nlm.nih.gov/pubmed/15980494" target="_blank">15980494</a>)
+              (Source: PubMed ID <a href="http://www.ncbi.nlm.nih.gov/pubmed/15980494" target="_blank" rel="noreferrer">15980494</a>)
             </li>
           </ul>
   }

--- a/src/ui/components/search/AlternateIsoFormRow.tsx
+++ b/src/ui/components/search/AlternateIsoFormRow.tsx
@@ -1,5 +1,5 @@
 import { UNIPROT_ACCESSION_URL } from "../../../constants/ExternalUrls";
-import { ANNOTATION_COLS, CONSEQUENCES, GENOMIC_COLS, INPUT_COLS } from "../../../constants/SearchResultTable";
+import { ANNOTATION_COLS, CONSEQUENCES, GENOMIC_COLS } from "../../../constants/SearchResultTable";
 import { MappingRecord } from "../../../utills/Convertor";
 import { fullAminoAcidName } from "../../../utills/Util";
 import Tool from "../../elements/Tool";
@@ -20,12 +20,13 @@ export function CanonicalIcon(props: { isCanonical: boolean | undefined }) {
     return <Tool el="span" tip="Non canonical isoform" className="protein-type-icon protein-type-icon--isoform">iso</Tool>
 }
 interface AlternateIsoFormRowProps {
-  record: MappingRecord
+  record: MappingRecord,
+  currStyle: object
 }
 function AlternateIsoFormRow(props: AlternateIsoFormRowProps) {
-  const { record } = props;
-  return <tr>
-    <td colSpan={INPUT_COLS + GENOMIC_COLS} />
+  const { record, currStyle } = props;
+  return <tr style={currStyle}>
+    <td colSpan={GENOMIC_COLS} />
     <td>
       <CanonicalIcon isCanonical={false} />
       <Spaces />
@@ -37,8 +38,7 @@ function AlternateIsoFormRow(props: AlternateIsoFormRowProps) {
     <td><Tool tip="The amino acid position in this isoform">{record.aaPos}</Tool></td>
     <td><Tool tip={aaChangeTip(record.aaChange)}>{record.aaChange}</Tool></td>
     <td><Tool tip={CONSEQUENCES.get(record.consequences!)} pos="up-right">{record.consequences}</Tool></td>
-    <td><br /><br /></td>
-    <td colSpan={ANNOTATION_COLS}><br /><br /></td>
+    <td colSpan={ANNOTATION_COLS+1}><br /><br /></td>
   </tr>
 }
 export default AlternateIsoFormRow;

--- a/src/ui/components/search/EveScore.tsx
+++ b/src/ui/components/search/EveScore.tsx
@@ -1,0 +1,22 @@
+export function getEveClassText(eveClass?: number) {
+    switch(eveClass) {
+        case 1: return "Benign";
+        case 2: return "Pathogenic";
+        case 3: return "Uncertain";
+        default: return "N/A";
+    }
+}
+
+export interface EveIconProps {
+    eveScore?: string
+    eveClass?: number
+}
+
+export function EveIcon(props: EveIconProps) {
+    switch(props.eveClass) {
+        case 1: return <><div className="circle-icon" style={{ background: 'Blue' }}></div></>;
+        case 2: return <><div className="circle-icon" style={{ background: 'Red' }}></div></>
+        case 3: return <><div className="circle-icon" style={{ background: 'LightGrey' }}></div></>;
+        default: return <>N/A</>;
+    }
+}

--- a/src/ui/components/search/NoteRow.tsx
+++ b/src/ui/components/search/NoteRow.tsx
@@ -1,8 +1,5 @@
-import { ENSEMBL_CHRM_URL, ENSEMBL_VIEW_URL } from "../../../constants/ExternalUrls";
-import {ALLELE, ANNOTATION_COLS, GENOMIC_COLS, PROTEIN_COLS, TOTAL_COLS} from "../../../constants/SearchResultTable";
+import {TOTAL_COLS} from "../../../constants/SearchResultTable";
 import { MappingRecord } from "../../../utills/Convertor";
-import Tool from "../../elements/Tool";
-import {INPUT_GEN, INPUT_PRO} from "../../../types/MappingResponse";
 
 interface NoteRowProps {
   record: MappingRecord,

--- a/src/ui/components/search/NoteRow.tsx
+++ b/src/ui/components/search/NoteRow.tsx
@@ -1,35 +1,21 @@
 import { ENSEMBL_CHRM_URL, ENSEMBL_VIEW_URL } from "../../../constants/ExternalUrls";
-import { ALLELE, ANNOTATION_COLS, GENOMIC_COLS, PROTEIN_COLS } from "../../../constants/SearchResultTable";
+import {ALLELE, ANNOTATION_COLS, GENOMIC_COLS, PROTEIN_COLS, TOTAL_COLS} from "../../../constants/SearchResultTable";
 import { MappingRecord } from "../../../utills/Convertor";
 import Tool from "../../elements/Tool";
+import {INPUT_GEN, INPUT_PRO} from "../../../types/MappingResponse";
 
-const NoteRow = (props: { record: MappingRecord }) => {
-  const { record } = props;
-  const positionUrl = ENSEMBL_VIEW_URL + record.chromosome + ':' + record.position + '-' + record.position;
-  return <tr>
-    <td>
-      <Tool tip="Click to see the a summary for this chromosome from Ensembl" pos="up-left">
-        <a href={ENSEMBL_CHRM_URL + record.chromosome} target="_blank" rel="noopener noreferrer">
-          {record.chromosome}
-        </a>
-      </Tool>
+interface NoteRowProps {
+  record: MappingRecord,
+  currStyle: object
+}
+
+const NoteRow = (props: NoteRowProps) => {
+  const { record, currStyle } = props;
+  return <tr style={currStyle}>
+    <td colSpan={TOTAL_COLS}>
+      <b>{record.input}</b> {record.note}
     </td>
-    <td>
-      <Tool tip="Click to see the region detail for this genomic coordinate from Ensembl" pos="up-left">
-        <a href={positionUrl} target="_blank" rel="noopener noreferrer">
-          {record.position}
-        </a>
-      </Tool>
-    </td>
-    <td><Tool tip="Variant ID provided by the user">{record.id}</Tool></td>
-    <td><Tool tip={ALLELE.get(record.refAllele)}>{record.refAllele}</Tool></td>
-    <td><Tool tip={ALLELE.get(record.altAllele)}>{record.altAllele}</Tool></td>
-    <td colSpan={GENOMIC_COLS + PROTEIN_COLS} style={{ borderRight: 0 }}>
-      {record.note}
-    </td>
-    <td colSpan={ANNOTATION_COLS} style={{ borderLeft: 0 }}><br /><br /></td>
   </tr>
 };
-
 
 export default NoteRow;

--- a/src/ui/components/search/PrimaryRow.tsx
+++ b/src/ui/components/search/PrimaryRow.tsx
@@ -22,18 +22,31 @@ import { ReactComponent as ChevronDownIcon } from "../../../images/chevron-down.
 import { ReactComponent as ChevronUpIcon } from "../../../images/chevron-up.svg"
 import { EmptyElement } from "../../../constants/Const";
 import { aaChangeTip, CanonicalIcon } from "./AlternateIsoFormRow";
+import {EveIcon, getEveClassText} from "./EveScore";
+import {INPUT_GEN, INPUT_PRO, INPUT_RS} from "../../../types/MappingResponse";
 
 const StructuralDetail = lazy(() => import(/* webpackChunkName: "StructuralDetail" */ "../structure/StructuralDetail"));
 const PopulationDetail = lazy(() => import(/* webpackChunkName: "PopulationDetail" */ "../population/PopulationDetail"));
 const FunctionalDetail = lazy(() => import(/* webpackChunkName: "FunctionalDetail" */ "../function/FunctionalDetail"));
 
 const getPrimaryRow = (record: MappingRecord, toggleOpenGroup: string, isoFormGroupExpanded: string, toggleIsoFormGroup: StringVoidFun,
-  annotationExpanded: string, toggleAnnotation: StringVoidFun, hasAltIsoForm: boolean) => {
+  annotationExpanded: string, toggleAnnotation: StringVoidFun, hasAltIsoForm: boolean, currStyle: object) => {
   let caddCss = getCaddCss(record.CADD);
   let caddTitle = getTitle(record.CADD);
   let strand = record.strand ? '(-)' : '(+)';
   if (!record.codon) {
     strand = '';
+  }
+  let inputStyle = {
+    gen: {
+      backgroundColor: record.type === INPUT_GEN ? "#FFFAF0" : ""
+    },
+    pro: {
+      backgroundColor: record.type === INPUT_PRO ? "#FFFAF0" : ""
+    },
+    rs: {
+      backgroundColor: record.type === INPUT_RS ? "#FFFAF0" : ""
+    }
   }
 
   const positionUrl = ENSEMBL_VIEW_URL + record.chromosome + ':' + record.position + '-' + record.position;
@@ -43,22 +56,22 @@ const getPrimaryRow = (record: MappingRecord, toggleOpenGroup: string, isoFormGr
   const populationKey = 'population-' + expandedGroup;
 
   return <Fragment key={`${toggleOpenGroup}-${record.isoform}`}>
-    <tr >
-      <td>
+    <tr style={currStyle} title={'Input: ' + record.input} >
+      <td style={inputStyle.gen}>
         <Tool tip="Click to see the a summary for this chromosome from Ensembl" pos="up-left">
           <a href={ENSEMBL_CHRM_URL + record.chromosome} target="_blank" rel="noopener noreferrer">
             {record.chromosome}
           </a>
         </Tool>
       </td>
-      <td>
+      <td style={inputStyle.gen}>
         <Tool tip="Click to see the region detail for this genomic coordinate from Ensembl" pos="up-left">
           <a href={positionUrl} target="_blank" rel="noopener noreferrer">
             {record.position}
           </a>
         </Tool>
       </td>
-      <td><Tool tip="Variant ID provided by the user">
+      <td style={inputStyle.rs}><Tool tip="Variant ID provided by the user">
         <a href={DBSNP_URL + record.id} target="_blank" rel="noopener noreferrer">{record.id}</a>
       </Tool></td>
       <td><Tool tip={ALLELE.get(record.refAllele)}>{record.refAllele}</Tool></td>
@@ -80,7 +93,7 @@ const getPrimaryRow = (record: MappingRecord, toggleOpenGroup: string, isoFormGr
           </a>
         </Tool>
       </td>
-      <td>
+      <td style={inputStyle.pro}>
         <div className="flex">
           <CanonicalIcon isCanonical={record.canonical} />
           <Spaces />
@@ -104,7 +117,7 @@ const getPrimaryRow = (record: MappingRecord, toggleOpenGroup: string, isoFormGr
       <td>
         <Tool tip={record.proteinName}>{getProteinName(record)}</Tool>
       </td>
-      <td><Tool tip="The amino acid position in this isoform">{record.aaPos}</Tool></td>
+      <td style={inputStyle.pro}><Tool tip="The amino acid position in this isoform">{record.aaPos}</Tool></td>
       <td><Tool tip={aaChangeTip(record.aaChange)}>{record.aaChange}</Tool></td>
       <td><Tool tip={CONSEQUENCES.get(record.consequences!)} pos="up-right">{record.consequences}</Tool></td>
       <td><Tool className="eve-score" tip={record.eveScore + '-' + getEveClassText(record.eveClass)}>
@@ -162,29 +175,6 @@ function getSignificancesButton(rowKey: string, buttonLabel: string, accession: 
       {buttonTag}
     </Tool>
   );
-}
-
-function getEveClassText(eveClass?: number) {
-  switch(eveClass) {
-    case 1: return "Benign";
-    case 2: return "Pathogenic";
-    case 3: return "Uncertain";
-    default: return "N/A";
-  }
-}
-
-interface EveIconProps {
-  eveScore?: string
-  eveClass?: number
-}
-
-function EveIcon(props: EveIconProps) {
-  switch(props.eveClass) {
-    case 1: return <><div className="circle-icon" style={{ background: 'Blue' }}></div></>;
-    case 2: return <><div className="circle-icon" style={{ background: 'Red' }}></div></>
-    case 3: return <><div className="circle-icon" style={{ background: 'LightGrey' }}></div></>;
-    default: return <>N/A</>;
-  }
 }
 
 export default getPrimaryRow;

--- a/src/ui/components/search/ResultTable.tsx
+++ b/src/ui/components/search/ResultTable.tsx
@@ -1,16 +1,13 @@
 import { useState } from "react"
-import InvalidTableRows from "./InvalidTableRows";
 import { StringVoidFun } from "../../../constants/CommonTypes";
 import { MappingRecord } from "../../../utills/Convertor";
-import { ParsedInput } from "../../../types/MappingResponse";
 import AlternateIsoFormRow from "./AlternateIsoFormRow";
-import { GENOMIC_COLS, INPUT_COLS, PROTEIN_COLS } from "../../../constants/SearchResultTable";
+import { GENOMIC_COLS, PROTEIN_COLS } from "../../../constants/SearchResultTable";
 import Tool from "../../elements/Tool";
 import getPrimaryRow from "./PrimaryRow";
 import NoteRow from "./NoteRow";
 
 interface ResultTableProps {
-  invalidInputs: Array<ParsedInput>
   mappings: Array<Array<Array<MappingRecord>>>
 }
 
@@ -35,10 +32,9 @@ function ResultTable(props: ResultTableProps) {
   }
 
   const tableRows = getTableRows(props.mappings, isoFormGroupExpanded, toggleIsoFormGroup, annotationExpanded, toggleAnnotation);
-  return <table className="unstriped" cellPadding="0" cellSpacing="0" id="resultTable">
+  return <table className="" cellPadding="0" cellSpacing="0" id="resultTable">
     <thead>
       <tr>
-        <Tool el="th" colSpan={INPUT_COLS} tip="User input is interpreted and displayed based on the reference genome (GRCh38)" pos="up-left">INPUT</Tool>
         <Tool el="th" colSpan={GENOMIC_COLS} tip="Gene and nucleotide level annotations">GENOMIC</Tool>
         <Tool el="th" colSpan={PROTEIN_COLS} tip="Amino acid/protein level annotations">PROTEIN</Tool>
         <Tool el="th" tip="Three types of annotations; functional, co-located variants and structural" pos="up-right">ANNOTATIONS</Tool>
@@ -52,7 +48,7 @@ function ResultTable(props: ResultTableProps) {
         <Tool el="th" className="sticky" tip="Alternative allele">Alt.</Tool>
         <Tool el="th" className="sticky" tip="HGNC short gene name">Gene</Tool>
         <Tool el="th" className="sticky" tip="Change of the codon containing the variant nucleotide the position of which is capitalised">Codon (strand)</Tool>
-        <Tool el="th" className="sticky" tip="CADD (Combined Annotation Dependent Depletion) phred-like score. Colours are defined in the key at the bottom of the page">CADD</Tool>
+        <Tool el="th" className="sticky" tip="CADD (Combined Annotation Dependent Depletion) phred-like score. Colours are defined in the key at the bottom of the page. Source: PubMed PMID 30371827">CADD</Tool>
         <Tool el="th" className="sticky" tip="The protein isoform the variant is mapped to. 
         By default this is the UniProt canonical isoform, however other isoforms are shown if necessary. 
         Alternative isoforms can be shown by expanding the arrow to the right of the isoform" tSize="xlarge">Isoform</Tool>
@@ -60,13 +56,12 @@ function ResultTable(props: ResultTableProps) {
         <Tool el="th" className="sticky" tip="Position of the amino acid containing the variant in the displayed isoform">AA pos.</Tool>
         <Tool el="th" className="sticky" tip="Three letter amino acid code for the reference and alternative alleles">AA change</Tool>
         <Tool el="th" className="sticky" tip="A description of the consequence of the variant">Consequence(s)</Tool>
-        <Tool el="th" className="sticky" tip="EVE (Evolutionary model of Variant Effects) score.">EVE</Tool>
+        <Tool el="th" className="sticky" tip="EVE (Evolutionary model of Variant Effects) score. Source: PubMed PMID 34707284">EVE</Tool>
         <th className="sticky">Click for details</th>
       </tr>
     </thead>
     <tbody>
       {tableRows}
-      <InvalidTableRows invalidInputs={props.invalidInputs} />
     </tbody>
   </table>
 }
@@ -74,19 +69,28 @@ function ResultTable(props: ResultTableProps) {
 const getTableRows = (mappings: MappingRecord[][][], isoFormGroupExpanded: string, toggleIsoFormGroup: StringVoidFun,
   annotationExpanded: string, toggleAnnotation: StringVoidFun) => {
   const tableRows: Array<JSX.Element> = [];
+  const rowStyle = { a: {backgroundColor: "#ebf6fb" }, b: {backgroundColor: "#fff" }}
+  let prevInput = ""
+  let currStyle = rowStyle.a
+  let swapStyle = (s: object) => (s == rowStyle.a) ? rowStyle.b : rowStyle.a;
   mappings.forEach((mapping, inputRecordIndex) => {
     mapping.forEach((matchingIsoForms) => {
       for (let index = 0; index < matchingIsoForms.length; index++) {
         const isoform = matchingIsoForms[index];
         const currentGroup = inputRecordIndex + '-' + isoform.canonicalAccession + '-' + isoform.position + '-' + isoform.altAllele;
+        let currInput = isoform.input
+        if (currInput != prevInput) {
+          currStyle = swapStyle(currStyle)
+        }
+        prevInput = currInput
         if (index === 0)
           if (isoform.note)
-            tableRows.push(<NoteRow record={isoform} key={isoform.chromosome + isoform.position + isoform.id + isoform.refAllele + isoform.altAllele} />)
+            tableRows.push(<NoteRow record={isoform} key={isoform.chromosome + isoform.position + isoform.id + isoform.refAllele + isoform.altAllele} currStyle={currStyle} />)
           else
             tableRows.push(getPrimaryRow(isoform, currentGroup, isoFormGroupExpanded, toggleIsoFormGroup, annotationExpanded,
-              toggleAnnotation, matchingIsoForms.length > 1))
+              toggleAnnotation, matchingIsoForms.length > 1, currStyle))
         else if (currentGroup === isoFormGroupExpanded)
-          tableRows.push(<AlternateIsoFormRow record={isoform} key={isoform.isoform} />)
+          tableRows.push(<AlternateIsoFormRow record={isoform} key={isoform.isoform} currStyle={currStyle} />)
       }
     })
   });

--- a/src/ui/components/search/ResultTable.tsx
+++ b/src/ui/components/search/ResultTable.tsx
@@ -72,14 +72,14 @@ const getTableRows = (mappings: MappingRecord[][][], isoFormGroupExpanded: strin
   const rowStyle = { a: {backgroundColor: "#ebf6fb" }, b: {backgroundColor: "#fff" }}
   let prevInput = ""
   let currStyle = rowStyle.a
-  let swapStyle = (s: object) => (s == rowStyle.a) ? rowStyle.b : rowStyle.a;
+  let swapStyle = (s: object) => (s === rowStyle.a) ? rowStyle.b : rowStyle.a;
   mappings.forEach((mapping, inputRecordIndex) => {
     mapping.forEach((matchingIsoForms) => {
       for (let index = 0; index < matchingIsoForms.length; index++) {
         const isoform = matchingIsoForms[index];
         const currentGroup = inputRecordIndex + '-' + isoform.canonicalAccession + '-' + isoform.position + '-' + isoform.altAllele;
         let currInput = isoform.input
-        if (currInput != prevInput) {
+        if (currInput !== prevInput) {
           currStyle = swapStyle(currStyle)
         }
         prevInput = currInput

--- a/src/ui/elements/Notify.ts
+++ b/src/ui/elements/Notify.ts
@@ -3,7 +3,7 @@ import "simple-react-notifications2/dist/index.css";
 import { Config } from "simple-react-notifications2/dist/NotificationContainer/NotificationContainer";
 
 const defaultConfig : Config = {
-  autoClose: 6000,
+  //autoClose: 6000,
   width: "400",
   position: "top-right",
   delay: 0,
@@ -12,11 +12,11 @@ const defaultConfig : Config = {
   onlyLast: false,
   rtl: false,
   newestOnTop: true,
-  animation: {
+  /*animation: {
     in: "fadeIn",
     out: "fadeOut",
     duration: 400
-  }
+  }*/
 };
 
 class Notify {

--- a/src/ui/pages/home/PasteVariantSearch.tsx
+++ b/src/ui/pages/home/PasteVariantSearch.tsx
@@ -18,26 +18,33 @@ function PasteVariantSearch(props: PasteVariantSearchProps) {
         '10\t43118436\t.\tA\tC\n' +
         '2\t233760498\t.\tG\tA\n' +
         '14\t89993420\t.\tA\tG')
-    props.updateAssembly(DEFAULT_ASSEMBLY)
+  };
+
+  const populateGnomAD = () => {
+    setSearchTerm('X-149498202-C-G\n' +
+        '10-43118436-A-C\n' +
+        '2-233760498-G-A\n' +
+        '14-89993420-A-G')
   };
 
   const populateHGVS = () => {
     setSearchTerm('NC_000023.11:g.149498202C>G\n' +
         'NC_000010.11:g.43118436A>C\n' +
         'NC_000002.12:g.233760498G>A')
-    props.updateAssembly(DEFAULT_ASSEMBLY)
   };
 
   const populateProtAC = () => {
     setSearchTerm('P22304 A205P\n' +
         'P07949 asn783thr\n' +
         'P22309 71 Gly Arg')
+    props.updateAssembly(DEFAULT_ASSEMBLY)
   };
 
   const populateRs = () => {
     setSearchTerm('rs864622779\n' +
         'rs587778656\n' +
         'rs4148323')
+    props.updateAssembly(DEFAULT_ASSEMBLY)
   };
 
   const protACTitle = "Supported format examples:\n" +
@@ -87,17 +94,22 @@ function PasteVariantSearch(props: PasteVariantSearchProps) {
                   <span title="Genome assembly conversion from GRCh37 to GRCh38 works for genomic input types only i.e. for input in VCF, HGVS or gnomAD formats. Protein position and DBSNP ID inputs are assumed to be in GRCh38.">Reference Genome Assembly</span>
                   <div className="assembly-radio-check">
                     <label>
-                    <input type="radio" name="grch" value="grch38" checked={props.assembly===Assembly.GRCh38} onChange={() => props.updateAssembly(Assembly.GRCh38)}/>
-                    GRCh38</label>
+                      <input type="radio" name="grch" value="grch38" checked={props.assembly===Assembly.GRCh38} onChange={() => props.updateAssembly(Assembly.GRCh38)}/>
+                      GRCh38</label>
                     <label>
                     <input type="radio" name="grch" value="grch37" checked={props.assembly===Assembly.GRCh37} onChange={() => props.updateAssembly(Assembly.GRCh37)}/>
                     GRCh37</label>
+                    <label>
+                      <input type="radio" name="grch" value="auto" checked={props.assembly===Assembly.AUTO} onChange={() => props.updateAssembly(Assembly.AUTO)}/>
+                      Auto-detect</label>
                   </div>
               </div>
               <div className="flex padding-bottom-1x">
                 <b>Examples:</b>
                 <Spaces count={2} />
                 <button onClick={populateVCF} className="ref-link" id="vcfExampleButton">VCF</button>
+                <Spaces count={2} />
+                <button onClick={populateGnomAD} className="ref-link" id="gnomadExampleButton">gnomAD</button>
                 <Spaces count={2} />
                 <button onClick={populateHGVS} className="ref-link" id="hgvsExampleButton">HGVS</button>
                 <Spaces count={2} />

--- a/src/ui/pages/home/RestApiComponent.tsx
+++ b/src/ui/pages/home/RestApiComponent.tsx
@@ -1,5 +1,7 @@
 import { API_URL } from '../../../constants/const';
 import Button from '../../elements/form/Button';
+import {QUERY} from "../../../constants/BrowserPaths";
+import {Link} from "react-router-dom";
 
 function RestApiComponent() {
   return <div id="api" className="card-table api">
@@ -25,6 +27,7 @@ function RestApiComponent() {
                 <li>Specific residues or ranges in genes, proteins or protein structures</li>
                 <li>Genomic positions or ranges using several different formats</li>
               </ul>
+              You can also use <b><Link to={QUERY} title="Direct query" id="directQuery">direct query</Link></b> to access annotations.
             </section>
           </section>
         </div>

--- a/src/ui/pages/query/QueryPage.tsx
+++ b/src/ui/pages/query/QueryPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { ParsedInput } from "../../../types/MappingResponse";
 import CaddLegendColors from "../../components/search/CaddLegendColors";
 import ResultTable from "../../components/search/ResultTable";
 import ResultTableButtonsLegend from "../../components/search/ResultTableButtonsLegend";
@@ -9,9 +8,10 @@ import {
   convertApiMappingToTableRecords,
   MappingRecord,
 } from "../../../utills/Convertor";
-import Notify from "../../elements/Notify";
 import DownloadModal from "../../modal/DownloadModal";
 import {mappings} from "../../../services/ProtVarService";
+import {ERROR, INFO, WARN} from "../../../types/MappingResponse";
+import Notify from "../../elements/Notify";
 
 // basic tests on query params
 const chromosomeRegExp = new RegExp("[a-zA-Z0-9]+");
@@ -35,26 +35,21 @@ const proteinExamples = [
 
 const gExamples = genomicExamples.map((ex, idx) => (
   <li key={"gEx" + idx}>
-    <pre>
-      <a href={ex}>{ex}</a>
-    </pre>
+    <a href={ex}>{ex}</a>
   </li>
 ));
 const pExamples = proteinExamples.map((ex, idx) => (
   <li key={"pEx" + idx}>
-    <pre>
-      <a href={ex}>{ex}</a>
-    </pre>
+    <a href={ex}>{ex}</a>
   </li>
 ));
 
-const InvalidQueryContent = () => (
+const QueryInfoContent = () => (
   <>
-    <h3>Invalid Query</h3>
+    <h3>Query</h3>
     <p>
-      The URL request format is invalid. Examples of valid requests to access
-      variant annotations using either genomic coordinates or protein accession
-      and position:
+      Direct access to variant annotations using permanent URL. Examples of valid requests using genomic coordinates
+      and protein information are given below.
     </p>
     Using genomic coordinates
     <ul>{gExamples}</ul>
@@ -136,7 +131,6 @@ const QueryPageContent = () => {
 
   const [userInput, setUserInput] = useState("");
   const [searchResults, setSearchResults] = useState<MappingRecord[][][]>([]);
-  const [invalidInputs, setInvalidInputs] = useState<Array<ParsedInput>>([]);
 
   useEffect(() => {
     const query = getQueryFromUrl(location);
@@ -144,13 +138,8 @@ const QueryPageContent = () => {
       setUserInput(query);
       mappings([query])
         .then((response) => {
-          const records = response.data.mappings.map(
-            convertApiMappingToTableRecords
-          );
+          const records = convertApiMappingToTableRecords(response.data.inputs)
           setSearchResults(records);
-          setInvalidInputs(response.data.invalidInputs);
-          if (response.data.invalidInputs.length > 0)
-            Notify.err("Some input rows are not valid");
         })
         .catch((err) => {
           console.log(err);
@@ -169,12 +158,12 @@ const QueryPageContent = () => {
           />
           <ResultTableButtonsLegend />
         </div>
-        <ResultTable invalidInputs={invalidInputs} mappings={searchResults} />
+        <ResultTable mappings={searchResults} />
         <CaddLegendColors />
       </div>
     </>
   ) : (
-    <InvalidQueryContent />
+    <QueryInfoContent />
   );
 
   //if (!searchResults || searchResults.length < 1) return <>Nothing!</>;

--- a/src/ui/pages/query/QueryPage.tsx
+++ b/src/ui/pages/query/QueryPage.tsx
@@ -10,8 +10,6 @@ import {
 } from "../../../utills/Convertor";
 import DownloadModal from "../../modal/DownloadModal";
 import {mappings} from "../../../services/ProtVarService";
-import {ERROR, INFO, WARN} from "../../../types/MappingResponse";
-import Notify from "../../elements/Notify";
 
 // basic tests on query params
 const chromosomeRegExp = new RegExp("[a-zA-Z0-9]+");

--- a/src/ui/pages/search/SearchResultPage.tsx
+++ b/src/ui/pages/search/SearchResultPage.tsx
@@ -4,7 +4,6 @@ import PaginationRow from "./PaginationRow";
 import { Redirect } from 'react-router-dom'
 import { NextPageFun, Page } from "../../../utills/AppHelper";
 import { MappingRecord } from "../../../utills/Convertor";
-import { ParsedInput } from "../../../types/MappingResponse";
 import DownloadModal from "../../modal/DownloadModal";
 import { MAX_IN_PLACE_DOWNLOAD_WITHOUT_EMAIL } from "../../../constants/const";
 import CaddLegendColors from "../../components/search/CaddLegendColors";
@@ -17,12 +16,11 @@ interface SearchResultPageProps {
   page: Page
   fetchNextPage: NextPageFun
   rows: MappingRecord[][][]
-  invalidInputs: Array<ParsedInput>
   loading: boolean
 }
 
 function SearchResultsPageContent(props: SearchResultPageProps) {
-  const { pastedInputs, file, page, invalidInputs, rows, fetchNextPage, loading } = props;
+  const { pastedInputs, file, page, rows, fetchNextPage, loading } = props;
   if (!rows || rows.length < 1)
     return <Redirect to="/" />
 
@@ -33,7 +31,7 @@ function SearchResultsPageContent(props: SearchResultPageProps) {
         <DownloadModal pastedInputs={pastedInputs} file={file} sendEmail={page.totalItems > MAX_IN_PLACE_DOWNLOAD_WITHOUT_EMAIL} />
         <ResultTableButtonsLegend />
       </div>
-      <ResultTable invalidInputs={invalidInputs} mappings={rows} />
+      <ResultTable mappings={rows} />
       <PaginationRow page={page} fetchNextPage={fetchNextPage} loading={loading} />
       <CaddLegendColors />
       <EveScoreColors />

--- a/src/utills/Convertor.ts
+++ b/src/utills/Convertor.ts
@@ -1,34 +1,40 @@
-import { GenomeProteinMapping } from "../types/MappingResponse";
+import {GenomeProteinMapping, INPUT_GEN, INPUT_PRO, INPUT_RS, UserInput, GenomicInput, ProteinInput, RSInput} from "../types/MappingResponse";
 
 export interface MappingRecord {
+  idx: number
+  input: string
+  type: string
+  // GENOMIC column properties
   chromosome: string
+  position: number
   id: string
   refAllele: string
+  altAllele: string
   geneName?: string
   codon?: string
+  strand?: boolean
   CADD?: string
-  position: number
-  altAllele: string
-  proteinName?: string
+  // PROTEIN column properties
+  canonical?: boolean   // display as can (true) or iso (false)
   isoform?: string
+  canonicalAccession: string | null
+  proteinName?: string
   aaPos?: number
-  aaChange?: string
+  aaChange?: string // display as refAA/variantAA
   refAA?: string
   variantAA?: string
+  cdsPosition?: number // not displayed or used anywhere
   consequences?: string
-  cdsPosition?: number
-  canonical?: boolean
-  canonicalAccession: string | null
+  eveScore?: string
+  eveClass?: number
+  // ANNOTATIONS column
   referenceFunctionUri?: string
   populationObservationsUri?: string
   proteinStructureUri?: string
-  ensp?: Array<TranslatedSequence>
-  strand?: boolean
-  ensg?: string
+  // OTHER properties
+  ensp?: Array<TranslatedSequence>  // passed to FunctionalDetail component
+  ensg?: string                     // passed to FunctionalDetail component
   note?: string
-  input: string
-  eveScore?: string
-  eveClass?: number
 }
 
 export interface TranslatedSequence {
@@ -36,87 +42,143 @@ export interface TranslatedSequence {
   ensts: string
 }
 
-function getBasicMapping(mapping: GenomeProteinMapping) {
-  return {
-    chromosome: mapping.chromosome,
-    position: mapping.geneCoordinateStart,
-    id: mapping.id,
-    refAllele: mapping.userAllele,
-    altAllele: mapping.variantAllele,
+function getBasicMapping(input: GenomicInput, mapping: GenomeProteinMapping) {
+  return {idx: 0,
+    chromosome: input.chr,
+    position: input.pos,
+    id: input.id,
+    refAllele: input.ref,
+    altAllele: input.alt,
     canonicalAccession: null,
-    input: mapping.input
+    input: input.inputStr,
+    type: input.type
   };
 }
-function getEmptyMapping(mapping: GenomeProteinMapping) {
-  const ret = getBasicMapping(mapping);
+function getEmptyMapping(input: GenomicInput, mapping: GenomeProteinMapping) {
+  const ret = getBasicMapping(input, mapping);
   ret.chromosome = "";
   ret.id = "";
   ret.refAllele = "";
   return ret;
 }
-export function convertApiMappingToTableRecords(mapping: GenomeProteinMapping) {
-  var genes: Array<Array<MappingRecord>> = [];
-  var variant = mapping.variantAllele;
+function emptyRow(input: UserInput) {
+  return {
+    idx: 0,
+    chromosome: "",
+    position: 0,
+    id: "",
+    refAllele: "",
+    altAllele: "",
+    canonicalAccession: null,
+    input: input.inputStr,
+    type: input.type
+  }
+}
 
-  mapping.genes.forEach((gene) => {
-    var rows: Array<MappingRecord> = [];
-    let ensg = gene.ensg;
-    gene.isoforms.forEach((isoform) => {
-      var record: MappingRecord = getEmptyMapping(mapping);
-      if (isoform.canonical || isoform.canonicalAccession === null) {
-        record.chromosome = mapping.chromosome;
-        record.id = mapping.id;
-        record.refAllele = gene.refAllele;
-        record.geneName = gene.geneName;
-        record.codon = isoform.refCodon + '/' + isoform.variantCodon;
-        if (gene.caddScore === null) record.CADD = '-';
-        else record.CADD = gene.caddScore.toString();
+function msgRow(input: UserInput, inputIdx:number, err: string) {
+  var genes: Array<Array<MappingRecord>> = [];
+  var rows: Array<MappingRecord> = [];
+  const empty: MappingRecord = emptyRow(input);
+  empty.note = err;
+  empty.idx = inputIdx
+  rows.push(empty);
+  genes.push(rows);
+  return genes
+}
+
+/*
+TableRow
+-PrimaryRow - contains all fields
+-IsoformRow     - contains isoform fields
+-MsgRow     - contains any message
+
+ */
+
+
+export function convertApiMappingToTableRecords(inputs: Array<GenomicInput|ProteinInput|RSInput>) {
+  var records: Array<Array<Array<MappingRecord>>> = [];
+  inputs.forEach((input, index) => {
+    if (input.messages.length > 0) {
+      var err = input.messages.map(m => m.text).join(" ")
+      records.push(msgRow(input, index, err))
+    }
+
+    if (input.type === INPUT_GEN && "mappings" in input) {
+      records.push(convertGenInputMappings(input, input, index))
+    }
+    else if ((input.type === INPUT_PRO || input.type === INPUT_RS) && "derivedGenomicInputs" in input) {
+      input.derivedGenomicInputs.forEach((gInput: GenomicInput) => {
+        records.push(convertGenInputMappings(input, gInput, index))
+      })
+    }
+  });
+  return records;
+}
+
+function convertGenInputMappings(originalInput: UserInput, gInput: GenomicInput, idx: number) {
+  if (gInput.mappings.length === 0 || (gInput.mappings.length === 1 && gInput.mappings[0].genes.length === 0)) {
+    if (!(originalInput.messages.length > 0 || gInput.messages.length > 0)) {
+      return msgRow(gInput, idx, "No mapping found")
+    }
+  }
+  var genes: Array<Array<MappingRecord>> = [];
+
+  gInput.mappings.forEach(mapping => {
+    mapping.genes.forEach((gene) => {
+      var rows: Array<MappingRecord> = [];
+      let ensg = gene.ensg;
+      gene.isoforms.forEach((isoform) => {
+        var record: MappingRecord = getEmptyMapping(gInput, mapping)
+        record.idx = idx;
+        record.type = originalInput.type
+        // GENOMIC
+        if (isoform.canonical || isoform.canonicalAccession === null) {
+          record.chromosome = gInput.chr;
+          record.id = gInput.id;
+          record.refAllele = gene.refAllele;
+          record.geneName = gene.geneName;
+          record.codon = isoform.refCodon + '/' + isoform.variantCodon;
+          record.strand = gene.reverseStrand;
+          if (gene.caddScore === null) record.CADD = '-';
+          else record.CADD = gene.caddScore.toString();
+        }
+        // PROTEIN
+        record.canonical = isoform.canonical;
+        record.isoform = isoform.accession;
+        record.canonicalAccession = isoform.canonicalAccession;
+        record.proteinName = isoform.proteinName;
+        record.aaPos = isoform.isoformPosition;
+        record.aaChange = isoform.refAA + '/' + isoform.variantAA;
+        record.refAA = isoform.refAA;
+        record.variantAA = isoform.variantAA;
+        record.cdsPosition = isoform.cdsPosition;
+        record.consequences = isoform.consequences;
         if (isoform.eveScore !== undefined && isoform.eveScore !== null) {
           record.eveScore = isoform.eveScore.toString();
           record.eveClass = isoform.eveClass;
-        }
-        else {
+        } else {
           record.eveScore = '-';
         }
-      }
-      record.altAllele = variant;
-      record.proteinName = isoform.proteinName;
-      record.isoform = isoform.accession;
-      record.aaPos = isoform.isoformPosition;
-      record.aaChange = isoform.refAA + '/' + isoform.variantAA;
-      record.refAA = isoform.refAA;
-      record.variantAA = isoform.variantAA;
-      record.consequences = isoform.consequences;
-      record.cdsPosition = isoform.cdsPosition;
-      record.canonical = isoform.canonical;
-      record.canonicalAccession = isoform.canonicalAccession;
-      record.referenceFunctionUri = isoform.referenceFunctionUri;
-      record.populationObservationsUri = isoform.populationObservationsUri;
-      record.proteinStructureUri = isoform.proteinStructureUri;
-      record.ensp = [];
-      record.strand = gene.reverseStrand;
-      if (isoform.translatedSequences !== undefined && isoform.translatedSequences.length > 0) {
-        var ensps: Array<TranslatedSequence> = [];
-        isoform.translatedSequences.forEach((translatedSeq) => {
-          var ensts: Array<string> = [];
-          translatedSeq.transcripts.forEach((transcript) => ensts.push(transcript.enst));
-          ensps.push({ ensp: translatedSeq.ensp, ensts: ensts.join() });
-        });
-        record.ensp = ensps;
-      }
-      record.ensg = ensg;
-      rows.push(record);
+        // ANNOTATIONS
+        record.referenceFunctionUri = isoform.referenceFunctionUri;
+        record.populationObservationsUri = isoform.populationObservationsUri;
+        record.proteinStructureUri = isoform.proteinStructureUri;
+        // OTHER
+        record.ensp = [];
+        if (isoform.translatedSequences !== undefined && isoform.translatedSequences.length > 0) {
+          var ensps: Array<TranslatedSequence> = [];
+          isoform.translatedSequences.forEach((translatedSeq) => {
+            var ensts: Array<string> = [];
+            translatedSeq.transcripts.forEach((transcript) => ensts.push(transcript.enst));
+            ensps.push({ensp: translatedSeq.ensp, ensts: ensts.join()});
+          });
+          record.ensp = ensps;
+        }
+        record.ensg = ensg;
+        rows.push(record);
+      });
+      genes.push(rows);
     });
-    genes.push(rows);
   });
-
-  if (genes.length === 0) {
-    var rows: Array<MappingRecord> = [];
-    const record: MappingRecord = getBasicMapping(mapping);
-    record.note = "Sorry, no mapping found"
-    rows.push(record);
-    genes.push(rows);
-  }
-
   return genes;
 }


### PR DESCRIPTION
Among other things, main changes include
- new mapping response structure - each input has its corresponding mappings
-- removed invalidInputs state; replaced invalidReasons with input messages of INFO, WARN and ERROR types
-- new note row for displaying each input messages
- added gnomAD support
- added auto-detect option
- remove automatic alternate row colouring, instead use same (bg) styling for multiple outputs of a single input
- remove INPUT COLS, highlight user inputs in result table
- query page changes
- added sources, and curated/predicted headers, check for empty category